### PR TITLE
Add Aegosexual Flag

### DIFF
--- a/flagdefs.cpp
+++ b/flagdefs.cpp
@@ -790,6 +790,26 @@ static Flag nonbinary_flag = Flag(
 	nonbinary_flag_commands
 );
 
+static GraphicsCommand aegosexual_pride_flag_commands[]={
+	GraphicsCommand(Rectangle,Left(h_4_0),Right(h_4_1),RGB(  0,  0,  0)),
+	GraphicsCommand(Rectangle,Left(h_4_1),Right(h_4_2),RGB(163,163,163)),
+	GraphicsCommand(Rectangle,Left(h_4_2),Right(h_4_3),RGB(255,255,255)),
+	GraphicsCommand(Rectangle,Left(h_4_3),Right(h_4_4),RGB(128,  0,128)),
+	GraphicsCommand(Quad,Point(0,h_4_0),Point(640,h_4_0),Point(560,h_4_1),Point(80,h_4_1),RGB(128,  0,128)),
+	GraphicsCommand(Quad,Point(80,h_4_1),Point(560,h_4_1),Point(480,h_4_2),Point(160,h_4_2),RGB(255,255,255)),
+	GraphicsCommand(Quad,Point(159,h_4_2),Point(481,h_4_2),Point(400,h_4_3),Point(240,h_4_3),RGB(163,163,163)), // Cheating slightly to prevent white touching white
+	GraphicsCommand(Triangle,Point(240,h_4_3),Point(400,h_4_3),Point(320,h_4_4),RGB(  0,  0,  0)),
+	GraphicsCommand(EndCommandList)
+};
+
+static Flag aegosexual_flag = Flag(
+	"aegosexual",
+	"The Aegosexual Pride Flag, formerly called the Autochorissexual Pride Flag",
+	"Created by tumblr user 'hunterinabrowncoat' in 2014",
+	"aego|autochorissexual|autochoris",
+	aegosexual_pride_flag_commands
+);
+
 Flag *PRIDE_FLAGS[]={
 	&rainbow_flag, &seven_stripe_rainbow_flag, &original_rainbow_flag, 
 	&trans_pride, &aromantic_flag, &asexual_flag, &bisexual_flag,
@@ -801,6 +821,6 @@ Flag *PRIDE_FLAGS[]={
 	&jewish_pride_flag, &littleender_flag, &trains_flag, &lipstick_lesbian_flag,
 	&gay_flag_of_south_africa, &pink_union_jack_flag, &rubber_pride_flag, 
 	&gay_brazil_flag,&demigirl_flag,&demiboy_flag,&omnisexual_flag,
-	&nonbinary_flag,
+	&nonbinary_flag, &aegosexual_flag,
 	NULL
 };


### PR DESCRIPTION
Uses aliases "aego", "autochorissexual", "autochoris".

Originally proposed at https://hunterinabrowncoat.tumblr.com/post/92665703641/id-like-to-humbly-put-forward-this-flag-as-a